### PR TITLE
Remove warnings in NewportSrc

### DIFF
--- a/motorApp/NewportSrc/HXPDriver.cpp
+++ b/motorApp/NewportSrc/HXPDriver.cpp
@@ -49,7 +49,6 @@ HXPController::HXPController(const char *portName, const char *IPAddress, int IP
                          0, 0)  // Default priority and stack size
 {
   int axis;
-  HXPAxis *pAxis;
   static const char *functionName = "HXPController::HXPController";
 
   axisNames_ = epicsStrDup("XYZUVW");
@@ -106,7 +105,7 @@ HXPController::HXPController(const char *portName, const char *IPAddress, int IP
   HXPFirmwareVersionGet(pollSocket_, firmwareVersion_);
 
   for (axis=0; axis<NUM_AXES; axis++) {
-    pAxis = new HXPAxis(this, axis);
+    new HXPAxis(this, axis);
   }
 
   startPoller(movingPollPeriod, idlePollPeriod, 2);
@@ -125,9 +124,7 @@ HXPController::HXPController(const char *portName, const char *IPAddress, int IP
 extern "C" int HXPCreateController(const char *portName, const char *IPAddress, int IPPort,
                                    int movingPollPeriod, int idlePollPeriod)
 {
-  HXPController *pHXPController
-    = new HXPController(portName, IPAddress, IPPort, movingPollPeriod/1000., idlePollPeriod/1000.);
-  pHXPController = NULL;
+  new HXPController(portName, IPAddress, IPPort, movingPollPeriod/1000., idlePollPeriod/1000.);
   return(asynSuccess);
 }
 
@@ -528,10 +525,9 @@ asynStatus HXPAxis::home(double baseVelocity, double slewVelocity, double accele
 
 asynStatus HXPAxis::stop(double acceleration )
 {
-  int status;
   //static const char *functionName = "HXPAxis::stop";
 
-  status = HXPGroupMoveAbort(moveSocket_, GROUP);
+  (void)HXPGroupMoveAbort(moveSocket_, GROUP);
 
   return asynSuccess;
 }

--- a/motorApp/NewportSrc/SMC100Driver.cpp
+++ b/motorApp/NewportSrc/SMC100Driver.cpp
@@ -49,7 +49,6 @@ SMC100Controller::SMC100Controller(const char *portName, const char *SMC100PortN
 {
   int axis;
   asynStatus status;
-  SMC100Axis *pAxis;
   static const char *functionName = "SMC100Controller::SMC100Controller";
   
   /* Connect to SMC100 controller */
@@ -61,7 +60,7 @@ SMC100Controller::SMC100Controller(const char *portName, const char *SMC100PortN
   }
   for (axis=0; axis<numAxes; axis++) {
   //for (axis=1; axis < (numAxes + 1); axis++) {
-    pAxis = new SMC100Axis(this, axis, stepSize);
+    new SMC100Axis(this, axis, stepSize);
   }
 
   startPoller(movingPollPeriod, idlePollPeriod, 2);

--- a/motorApp/NewportSrc/XPSController.cpp
+++ b/motorApp/NewportSrc/XPSController.cpp
@@ -92,6 +92,7 @@ Versions: Release 4-5 and higher.
 
 #include <epicsExport.h>
 #include "XPSController.h"
+//warning: 'XPSController::initializeProfile' hides overloaded virtual function [-Woverloaded-virtual]
 #include "XPS_C8_drivers.h"
 #include "xps_ftp.h"
 #include "XPSAxis.h"
@@ -109,13 +110,13 @@ typedef struct {
   char *NoCorrector;
 } CorrectorTypes_t;
 
-const static CorrectorTypes_t CorrectorTypes = { 
-  "PositionerCorrectorPIPosition",
-  "PositionerCorrectorPIDFFVelocity",
-  "PositionerCorrectorPIDFFAcceleration",
-  "PositionerCorrectorPIDDualFFVoltage",
-  "NoCorrector"
-};
+//const static CorrectorTypes_t CorrectorTypes = { 
+//  "PositionerCorrectorPIPosition",
+//  "PositionerCorrectorPIDFFVelocity",
+//  "PositionerCorrectorPIDFFAcceleration",
+//  "PositionerCorrectorPIDDualFFVoltage",
+//  "NoCorrector"
+//};
 
 /* The maximum size of the item names in gathering, e.g. "GROUP2.POSITIONER1.CurrentPosition" */
 #define MAX_GATHERING_AXIS_STRING 60
@@ -1434,7 +1435,7 @@ static const iocshArg XPSCreateControllerArg7 = {"Set position settling time (ms
 static const iocshArg * const XPSCreateControllerArgs[] = {&XPSCreateControllerArg0,
                                                            &XPSCreateControllerArg1,
                                                            &XPSCreateControllerArg2,
-                                                           &XPSCreateControllerArg2,
+                                                           &XPSCreateControllerArg3,
                                                            &XPSCreateControllerArg4,
                                                            &XPSCreateControllerArg5,
                                                            &XPSCreateControllerArg6,

--- a/motorApp/NewportSrc/XPS_C8_drivers.cpp
+++ b/motorApp/NewportSrc/XPS_C8_drivers.cpp
@@ -28,7 +28,7 @@
 extern "C"
 {
 #else
-#typedef int bool;  /* C does not know bool, only C++ */
+typedef int bool;  /* C does not know bool, only C++ */
 #endif
 
 #define DLL_VERSION "Library version for XPS-C8 Firmware V2.6.x"
@@ -90,10 +90,8 @@ int __stdcall ControllerMotionKernelTimeLoadGet (int SocketIndex, double * CPUTo
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", CPUTotalLoadRatio);
@@ -142,10 +140,8 @@ int __stdcall ControllerStatusGet (int SocketIndex, int * ControllerStatus)
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", ControllerStatus);
@@ -231,10 +227,8 @@ int __stdcall ElapsedTimeGet (int SocketIndex, double * ElapsedTime)
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", ElapsedTime);
@@ -515,10 +509,8 @@ int __stdcall TimerGet (int SocketIndex, char * TimerName, int * FrequencyTicks)
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", FrequencyTicks);
@@ -1261,10 +1253,8 @@ int __stdcall EventExtendedStart (int SocketIndex, int * ID)
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", ID);
@@ -1578,10 +1568,8 @@ int __stdcall GatheringCurrentNumberGet (int SocketIndex, int * CurrentNumber, i
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", CurrentNumber);
@@ -2019,10 +2007,8 @@ int __stdcall GatheringExternalCurrentNumberGet (int SocketIndex, int * CurrentN
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", CurrentNumber);
@@ -2222,10 +2208,8 @@ int __stdcall DoubleGlobalArrayGet (int SocketIndex, int Number, double * Double
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", DoubleValue);
@@ -2335,10 +2319,8 @@ int __stdcall GPIOAnalogGet (int SocketIndex, int NbElements, char * GPIONameLis
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 
 		for (int i = 0; i < NbElements; i++)
 		{
@@ -2488,10 +2470,8 @@ int __stdcall GPIOAnalogGainGet (int SocketIndex, int NbElements, char * GPIONam
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 
 		for (int i = 0; i < NbElements; i++)
 		{
@@ -2605,10 +2585,8 @@ int __stdcall GPIODigitalGet (int SocketIndex, char * GPIOName, unsigned short *
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%hu", DigitalValue);
@@ -2695,10 +2673,8 @@ int __stdcall GroupAccelerationSetpointGet (int SocketIndex, char * GroupName, i
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 
 		for (int i = 0; i < NbElements; i++)
 		{
@@ -2820,10 +2796,8 @@ int __stdcall GroupCorrectorOutputGet (int SocketIndex, char * GroupName, int Nb
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 
 		for (int i = 0; i < NbElements; i++)
 		{
@@ -2880,10 +2854,8 @@ int __stdcall GroupCurrentFollowingErrorGet (int SocketIndex, char * GroupName, 
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 
 		for (int i = 0; i < NbElements; i++)
 		{
@@ -3126,10 +3098,8 @@ int __stdcall GroupJogParametersGet (int SocketIndex, char * GroupName, int NbEl
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 
 		for (int i = 0; i < NbElements; i++)
 		{
@@ -3190,10 +3160,8 @@ int __stdcall GroupJogCurrentGet (int SocketIndex, char * GroupName, int NbEleme
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 
 		for (int i = 0; i < NbElements; i++)
 		{
@@ -3524,10 +3492,8 @@ int __stdcall GroupPositionCorrectedProfilerGet (int SocketIndex, char * GroupNa
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", CorrectedProfilerPositionX);
@@ -3583,10 +3549,8 @@ int __stdcall GroupPositionCurrentGet (int SocketIndex, char * GroupName, int Nb
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 
 		for (int i = 0; i < NbElements; i++)
 		{
@@ -3634,10 +3598,8 @@ int __stdcall GroupPositionPCORawEncoderGet (int SocketIndex, char * GroupName, 
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", PCORawPositionX);
@@ -3693,10 +3655,8 @@ int __stdcall GroupPositionSetpointGet (int SocketIndex, char * GroupName, int N
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 
 		for (int i = 0; i < NbElements; i++)
 		{
@@ -3753,10 +3713,8 @@ int __stdcall GroupPositionTargetGet (int SocketIndex, char * GroupName, int NbE
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 
 		for (int i = 0; i < NbElements; i++)
 		{
@@ -3900,10 +3858,8 @@ int __stdcall GroupStatusGet (int SocketIndex, char * GroupName, int * Status)
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", Status);
@@ -4002,10 +3958,8 @@ int __stdcall GroupVelocityCurrentGet (int SocketIndex, char * GroupName, int Nb
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 
 		for (int i = 0; i < NbElements; i++)
 		{
@@ -4479,10 +4433,8 @@ int __stdcall PositionerCorrectorNotchFiltersGet (int SocketIndex, char * Positi
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", NotchFrequency1);
@@ -4579,7 +4531,7 @@ int __stdcall PositionerCorrectorPIDFFAccelerationGet (int SocketIndex, char * P
 	int ret = -1; 
 	char ExecuteMethod[SIZE_EXECUTE_METHOD]; 
 	char *ReturnedValue = (char *) malloc (sizeof(char) * SIZE_SMALL); 
-	int boolScanTmp;
+	int boolScanTmp = 0;
 
 	/* Convert to string */ 
 	sprintf (ExecuteMethod, "PositionerCorrectorPIDFFAccelerationGet (%s,bool *,double *,double *,double *,double *,double *,double *,double *,double *,double *,double *,double *)", PositionerName);
@@ -4594,10 +4546,8 @@ int __stdcall PositionerCorrectorPIDFFAccelerationGet (int SocketIndex, char * P
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", &boolScanTmp);
@@ -4713,7 +4663,7 @@ int __stdcall PositionerCorrectorPIDFFVelocityGet (int SocketIndex, char * Posit
 	int ret = -1; 
 	char ExecuteMethod[SIZE_EXECUTE_METHOD]; 
 	char *ReturnedValue = (char *) malloc (sizeof(char) * SIZE_SMALL); 
-	int boolScanTmp;
+	int boolScanTmp = 0;
 
 	/* Convert to string */ 
 	sprintf (ExecuteMethod, "PositionerCorrectorPIDFFVelocityGet (%s,bool *,double *,double *,double *,double *,double *,double *,double *,double *,double *,double *,double *)", PositionerName);
@@ -4728,10 +4678,8 @@ int __stdcall PositionerCorrectorPIDFFVelocityGet (int SocketIndex, char * Posit
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", &boolScanTmp);
@@ -4866,10 +4814,8 @@ int __stdcall PositionerCorrectorPIDDualFFVoltageGet (int SocketIndex, char * Po
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", &boolScanTmp);
@@ -4990,10 +4936,8 @@ int __stdcall PositionerCorrectorPIPositionGet (int SocketIndex, char * Position
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", &boolScanTmp);
@@ -5091,10 +5035,8 @@ int __stdcall PositionerCurrentVelocityAccelerationFiltersGet (int SocketIndex, 
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", CurrentVelocityCutOffFrequency);
@@ -5176,10 +5118,8 @@ int __stdcall PositionerDriverFiltersGet (int SocketIndex, char * PositionerName
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", KI);
@@ -5270,10 +5210,8 @@ int __stdcall PositionerDriverPositionOffsetsGet (int SocketIndex, char * Positi
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", StagePositionOffset);
@@ -5317,10 +5255,8 @@ int __stdcall PositionerDriverStatusGet (int SocketIndex, char * PositionerName,
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", DriverStatus);
@@ -5410,10 +5346,8 @@ int __stdcall PositionerEncoderAmplitudeValuesGet (int SocketIndex, char * Posit
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", CalibrationSinusAmplitude);
@@ -5466,10 +5400,8 @@ int __stdcall PositionerEncoderCalibrationParametersGet (int SocketIndex, char *
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", SinusOffset);
@@ -5519,10 +5451,8 @@ int __stdcall PositionerErrorGet (int SocketIndex, char * PositionerName, int * 
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", ErrorCode);
@@ -5563,10 +5493,8 @@ int __stdcall PositionerErrorRead (int SocketIndex, char * PositionerName, int *
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", ErrorCode);
@@ -5656,10 +5584,8 @@ int __stdcall PositionerExcitationSignalGet (int SocketIndex, char * PositionerN
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", Mode);
@@ -5745,10 +5671,8 @@ int __stdcall PositionerExternalLatchPositionGet (int SocketIndex, char * Positi
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", Position);
@@ -5789,10 +5713,8 @@ int __stdcall PositionerHardwareStatusGet (int SocketIndex, char * PositionerNam
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", HardwareStatus);
@@ -5879,10 +5801,8 @@ int __stdcall PositionerHardInterpolatorFactorGet (int SocketIndex, char * Posit
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", InterpolationFactor);
@@ -5957,10 +5877,8 @@ int __stdcall PositionerMaximumVelocityAndAccelerationGet (int SocketIndex, char
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", MaximumVelocity);
@@ -6008,10 +5926,8 @@ int __stdcall PositionerMotionDoneGet (int SocketIndex, char * PositionerName, d
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", PositionWindow);
@@ -6136,10 +6052,8 @@ int __stdcall PositionerPositionCompareAquadBWindowedGet (int SocketIndex, char 
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", MinimumPosition);
@@ -6225,10 +6139,8 @@ int __stdcall PositionerPositionCompareGet (int SocketIndex, char * PositionerNa
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", MinimumPosition);
@@ -6379,10 +6291,8 @@ int __stdcall PositionerPositionComparePulseParametersGet (int SocketIndex, char
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", PCOPulseWidth);
@@ -6461,10 +6371,8 @@ int __stdcall PositionerRawEncoderPositionGet (int SocketIndex, char * Positione
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", RawEncoderPosition);
@@ -6505,10 +6413,8 @@ int __stdcall PositionersEncoderIndexDifferenceGet (int SocketIndex, char * Posi
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", distance);
@@ -6550,10 +6456,8 @@ int __stdcall PositionerSGammaExactVelocityAjustedDisplacementGet (int SocketInd
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", AdjustedDisplacement);
@@ -6597,10 +6501,8 @@ int __stdcall PositionerSGammaParametersGet (int SocketIndex, char * PositionerN
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", Velocity);
@@ -6687,10 +6589,8 @@ int __stdcall PositionerSGammaPreviousMotionTimesGet (int SocketIndex, char * Po
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", SettingTime);
@@ -6819,10 +6719,8 @@ int __stdcall PositionerTimeFlasherGet (int SocketIndex, char * PositionerName, 
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", MinimumPosition);
@@ -6973,10 +6871,8 @@ int __stdcall PositionerUserTravelLimitsGet (int SocketIndex, char * PositionerN
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", UserMinimumTarget);
@@ -7055,10 +6951,8 @@ int __stdcall PositionerDACOffsetGet (int SocketIndex, char * PositionerName, sh
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%hd", DACOffset1);
@@ -7139,10 +7033,8 @@ int __stdcall PositionerDACOffsetDualGet (int SocketIndex, char * PositionerName
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%hd", PrimaryDACOffset1);
@@ -7231,10 +7123,8 @@ int __stdcall PositionerCorrectorAutoTuning (int SocketIndex, char * PositionerN
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", KP);
@@ -7281,10 +7171,8 @@ int __stdcall PositionerAccelerationAutoScaling (int SocketIndex, char * Positio
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", Scaling);
@@ -7541,10 +7429,8 @@ int __stdcall MultipleAxesPVTPulseOutputGet (int SocketIndex, char * GroupName, 
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", StartElement);
@@ -7922,10 +7808,8 @@ int __stdcall GroupSpinParametersGet (int SocketIndex, char * GroupName, double 
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", Velocity);
@@ -7970,10 +7854,8 @@ int __stdcall GroupSpinCurrentGet (int SocketIndex, char * GroupName, double * V
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", Velocity);
@@ -8276,10 +8158,8 @@ int __stdcall XYLineArcPulseOutputGet (int SocketIndex, char * GroupName, double
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", StartLength);
@@ -8331,10 +8211,8 @@ int __stdcall XYZGroupPositionCorrectedProfilerGet (int SocketIndex, char * Grou
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", CorrectedProfilerPositionX);
@@ -8773,10 +8651,8 @@ int __stdcall CPUCoreAndBoardSupplyVoltagesGet (int SocketIndex, double * Voltag
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", VoltageCPUCore);
@@ -8838,10 +8714,8 @@ int __stdcall CPUTemperatureAndFanSpeedGet (int SocketIndex, double * CPUTempera
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", CPUTemperature);
@@ -9753,10 +9627,8 @@ int __stdcall GatheringUserDatasGet (int SocketIndex, double * UserData1, double
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", UserData1);
@@ -9822,10 +9694,8 @@ int __stdcall ControllerMotionKernelPeriodMinMaxGet (int SocketIndex, double * M
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", MinimumCorrectorPeriod);

--- a/motorApp/NewportSrc/asynOctetSocket.cpp
+++ b/motorApp/NewportSrc/asynOctetSocket.cpp
@@ -178,8 +178,8 @@ void SendAndReceive (int SocketIndex, char buffer[], char valueRtrn[], int retur
                                             &nbytesIn,
                                             &eomReason);
             asynPrint(psock->pasynUser, ASYN_TRACEIO_DRIVER,
-                  "SendAndReceive, received: nread=%d, returnSize-nread=%d, nbytesIn=%d\n",
-                  (int)nread, returnSize-nread, (int)nbytesIn);
+                  "SendAndReceive, received: nread=%d, returnSize-nread=%ld, nbytesIn=%d\n",
+                      (int)nread, (long)(returnSize-nread), (int)nbytesIn);
             nread += nbytesIn;
         }
     } else {
@@ -259,8 +259,8 @@ int ReadXPSSocket (int SocketIndex, char valueRtrn[], int returnSize, double tim
                                         &nbytesIn,
                                         &eomReason);
         asynPrint(psock->pasynUser, ASYN_TRACEIO_DRIVER,
-              "ReadXPSSocket, received: nread=%d, returnSize-nread=%d, nbytesIn=%d\n",
-              (int)nread, returnSize-nread, (int)nbytesIn);
+              "ReadXPSSocket, received: nread=%d, returnSize-nread=%ld, nbytesIn=%d\n",
+                  (int)nread, (long)(returnSize-nread), (int)nbytesIn);
         nread += nbytesIn;
     } while ((status==asynSuccess) && 
              (strcmp(valueRtrn + nread - strlen(XPS_TERMINATOR), XPS_TERMINATOR) != 0));

--- a/motorApp/NewportSrc/drvMM4000Asyn.c
+++ b/motorApp/NewportSrc/drvMM4000Asyn.c
@@ -929,8 +929,8 @@ static int sendOnly(MM4000Controller *pController, char *outputBuff)
         if (status != asynSuccess)
         {
             asynPrint(pController->pasynUser, ASYN_TRACE_ERROR,
-                      "drvMM4000Asyn:sendOnly: error sending command %s, sent=%d, status=%d\n",
-                      outputBuff, nActual, status);
+                      "drvMM4000Asyn:sendOnly: error sending command %s, sent=%ld, status=%d\n",
+                      outputBuff, (long)nActual, status);
         }
     }
     return(status);

--- a/motorApp/NewportSrc/drvXPSAsyn.c
+++ b/motorApp/NewportSrc/drvXPSAsyn.c
@@ -1583,7 +1583,6 @@ int XPSConfigAxis(int card,                   /* specify which controller 0-up*/
     XPSController *pController;
     AXIS_HDL pAxis;
     char *index;
-    int status;
     double stepSize;
 
     if (numXPSControllers < 1) {
@@ -1614,12 +1613,12 @@ int XPSConfigAxis(int card,                   /* specify which controller 0-up*/
     stepSize = strtod(stepsPerUnit, NULL);
     pAxis->stepSize = 1./stepSize;
     /* Read some information from the controller for this axis */
-    status = PositionerSGammaParametersGet(pAxis->pollSocket,
-                                           pAxis->positionerName,
-                                           &pAxis->velocity,
-                                           &pAxis->accel,
-                                           &pAxis->minJerkTime,
-                                           &pAxis->maxJerkTime);
+    (void)PositionerSGammaParametersGet(pAxis->pollSocket,
+                                        pAxis->positionerName,
+                                        &pAxis->velocity,
+                                        &pAxis->accel,
+                                        &pAxis->minJerkTime,
+                                        &pAxis->maxJerkTime);
     pAxis->mutexId = epicsMutexMustCreate();
 
     /* Send a signal to the poller task which will make it do a poll, 
@@ -2308,7 +2307,7 @@ static const iocshArg XPSConfigArg5 = {"Idle poll rate", iocshArgInt};
 static const iocshArg * const XPSConfigArgs[6] = {&XPSConfigArg0,
                                                   &XPSConfigArg1,
                                                   &XPSConfigArg2,
-                                                  &XPSConfigArg2,
+                                                  &XPSConfigArg3,
                                                   &XPSConfigArg4,
                                                   &XPSConfigArg5};
 static const iocshFuncDef configXPS = {"XPSConfig", 6, XPSConfigArgs};

--- a/motorApp/NewportSrc/hxp_drivers.cpp
+++ b/motorApp/NewportSrc/hxp_drivers.cpp
@@ -28,7 +28,7 @@
 extern "C"
 {
 #else
-#typedef int bool;  /* C does not know bool, only C++ */
+typedef int bool;  /* C does not know bool, only C++ */
 #endif
 
 
@@ -47,7 +47,7 @@ void ReplaceCharacter (char *strSourceInOut, char oldChar, char newChar, char st
 		pt = strchr(ptNext, startChar); 
 		if (pt != NULL) 
 		{
-			*pt++;
+                	*pt++; /* warning: value computed is not used [-Wunused-value] */
 			while ((pt != NULL) && (*pt != endChar))
 			{
 				if (*pt == oldChar)
@@ -187,10 +187,8 @@ int __stdcall HXPControllerMotionKernelTimeLoadGet (int SocketIndex, double * CP
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", CPUTotalLoadRatio);
@@ -239,10 +237,8 @@ int __stdcall HXPElapsedTimeGet (int SocketIndex, double * ElapsedTime)
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", ElapsedTime);
@@ -488,10 +484,8 @@ int __stdcall HXPTimerGet (int SocketIndex, char * TimerName, int * FrequencyTic
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", FrequencyTicks);
@@ -1199,10 +1193,8 @@ int __stdcall HXPEventExtendedStart (int SocketIndex, int * ID)
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", ID);
@@ -1521,10 +1513,8 @@ int __stdcall HXPGatheringCurrentNumberGet (int SocketIndex, int * CurrentNumber
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", CurrentNumber);
@@ -1889,10 +1879,8 @@ int __stdcall HXPGatheringExternalCurrentNumberGet (int SocketIndex, int * Curre
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", CurrentNumber);
@@ -2046,10 +2034,8 @@ int __stdcall HXPDoubleGlobalArrayGet (int SocketIndex, int Number, double * Dou
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", DoubleValue);
@@ -2164,10 +2150,8 @@ int __stdcall HXPGPIOAnalogGet (int SocketIndex, int NbElements, char * GPIOName
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 
 		for (int i = 0; i < NbElements; i++)
 		{
@@ -2327,10 +2311,8 @@ int __stdcall HXPGPIOAnalogGainGet (int SocketIndex, int NbElements, char * GPIO
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 
 		for (int i = 0; i < NbElements; i++)
 		{
@@ -2449,10 +2431,8 @@ int __stdcall HXPGPIODigitalGet (int SocketIndex, char * GPIOName, unsigned shor
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%hu", DigitalValue);
@@ -2539,10 +2519,8 @@ int __stdcall HXPGroupCorrectorOutputGet (int SocketIndex, char * GroupName, int
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 
 		for (int i = 0; i < NbElements; i++)
 		{
@@ -2946,10 +2924,8 @@ int __stdcall HXPGroupPositionCorrectedProfilerGet (int SocketIndex, char * Grou
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", CorrectedProfilerPositionX);
@@ -3005,10 +2981,8 @@ int __stdcall HXPGroupPositionCurrentGet (int SocketIndex, char * GroupName, int
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 
 		for (int i = 0; i < NbElements; i++)
 		{
@@ -3065,10 +3039,8 @@ int __stdcall HXPGroupPositionSetpointGet (int SocketIndex, char * GroupName, in
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 
 		for (int i = 0; i < NbElements; i++)
 		{
@@ -3125,10 +3097,8 @@ int __stdcall HXPGroupPositionTargetGet (int SocketIndex, char * GroupName, int 
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 
 		for (int i = 0; i < NbElements; i++)
 		{
@@ -3173,10 +3143,8 @@ int __stdcall HXPGroupStatusGet (int SocketIndex, char * GroupName, int * Status
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", Status);
@@ -3515,10 +3483,8 @@ int __stdcall HXPPositionerCorrectorNotchFiltersGet (int SocketIndex, char * Pos
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", NotchFrequency1);
@@ -3630,10 +3596,8 @@ int __stdcall HXPPositionerCorrectorPIDFFAccelerationGet (int SocketIndex, char 
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", &boolScanTmp);
@@ -3764,10 +3728,8 @@ int __stdcall HXPPositionerCorrectorPIDFFVelocityGet (int SocketIndex, char * Po
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", &boolScanTmp);
@@ -3902,10 +3864,8 @@ int __stdcall HXPPositionerCorrectorPIDDualFFVoltageGet (int SocketIndex, char *
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", &boolScanTmp);
@@ -4026,10 +3986,8 @@ int __stdcall HXPPositionerCorrectorPIPositionGet (int SocketIndex, char * Posit
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", &boolScanTmp);
@@ -4161,10 +4119,8 @@ int __stdcall HXPPositionerCurrentVelocityAccelerationFiltersGet (int SocketInde
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", CurrentVelocityCutOffFrequency);
@@ -4208,10 +4164,8 @@ int __stdcall HXPPositionerDriverStatusGet (int SocketIndex, char * PositionerNa
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", DriverStatus);
@@ -4301,10 +4255,8 @@ int __stdcall HXPPositionerEncoderAmplitudeValuesGet (int SocketIndex, char * Po
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", CalibrationSinusAmplitude);
@@ -4357,10 +4309,8 @@ int __stdcall HXPPositionerEncoderCalibrationParametersGet (int SocketIndex, cha
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", SinusOffset);
@@ -4410,10 +4360,8 @@ int __stdcall HXPPositionerErrorGet (int SocketIndex, char * PositionerName, int
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", ErrorCode);
@@ -4454,10 +4402,8 @@ int __stdcall HXPPositionerErrorRead (int SocketIndex, char * PositionerName, in
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", ErrorCode);
@@ -4544,10 +4490,8 @@ int __stdcall HXPPositionerHardwareStatusGet (int SocketIndex, char * Positioner
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", HardwareStatus);
@@ -4634,10 +4578,8 @@ int __stdcall HXPPositionerHardInterpolatorFactorGet (int SocketIndex, char * Po
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", InterpolationFactor);
@@ -4712,10 +4654,8 @@ int __stdcall HXPPositionerMaximumVelocityAndAccelerationGet (int SocketIndex, c
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", MaximumVelocity);
@@ -4763,10 +4703,8 @@ int __stdcall HXPPositionerMotionDoneGet (int SocketIndex, char * PositionerName
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", PositionWindow);
@@ -4857,10 +4795,8 @@ int __stdcall HXPPositionerSGammaExactVelocityAjustedDisplacementGet (int Socket
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", AdjustedDisplacement);
@@ -4904,10 +4840,8 @@ int __stdcall HXPPositionerSGammaParametersGet (int SocketIndex, char * Position
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", Velocity);
@@ -4994,10 +4928,8 @@ int __stdcall HXPPositionerSGammaPreviousMotionTimesGet (int SocketIndex, char *
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", SettingTime);
@@ -5123,10 +5055,8 @@ int __stdcall HXPPositionerUserTravelLimitsGet (int SocketIndex, char * Position
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", UserMinimumTarget);
@@ -5295,10 +5225,8 @@ int __stdcall HXPHexapodCoordinatesGet (int SocketIndex, char * GroupName, char 
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", Xout);
@@ -5399,10 +5327,8 @@ int __stdcall HXPHexapodCoordinateSystemGet (int SocketIndex, char * GroupName, 
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", X);
@@ -5522,10 +5448,8 @@ int __stdcall HXPControllerStatusGet (int SocketIndex, int * ControllerStatus)
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%d", ControllerStatus);
@@ -5751,10 +5675,8 @@ int __stdcall HXPCPUCoreAndBoardSupplyVoltagesGet (int SocketIndex, double * Vol
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", VoltageCPUCore);
@@ -5816,10 +5738,8 @@ int __stdcall HXPCPUTemperatureAndFanSpeedGet (int SocketIndex, double * CPUTemp
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", CPUTemperature);
@@ -6686,10 +6606,8 @@ int __stdcall HXPGatheringUserDatasGet (int SocketIndex, double * UserData1, dou
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", UserData1);
@@ -6755,10 +6673,8 @@ int __stdcall HXPControllerMotionKernelPeriodMinMaxGet (int SocketIndex, double 
 	if (ret == 0) 
 	{ 
 		char * pt;
-		char * ptNext;
 
 		pt = ReturnedValue;
-		ptNext = NULL;
 		if (pt != NULL) pt = strchr (pt, ',');
 		if (pt != NULL) pt++;
 		if (pt != NULL) sscanf (pt, "%lf", MinimumCorrectorPeriod);


### PR DESCRIPTION
Remove compilation warnings:
-  pAxis = new XXXH(this, axis); // pAxis is not needed. remove it

-#typedef int bool;
 This should be "typedef" without the '#'
- Unused variables:
  char *ptNext;
  ptNext = 0;
  While older compilers are OK with this, new compilers detect that the
  variable isnever used and give a warning.
  Remove the variable.
- printf ("%d", sizeof(nRead)"
  This did work on 32 bit systems, but for both 64 and 32 bit systems we can
  cast nRead to long and use "%ld" to print it.
- status = XXX();
  status is never looked at.
  Remove it.
- Remove unused function
- Fix one bug where arg2 is messed up with arg3

Note:
  Some castings from "string" into "char *" needs to be addressed later.
