### PR TITLE
Add Makefile for ESS EPICS Environment EEE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,18 @@
-#Makefile at top of application tree
-# "#!" marks lines that can be uncommented.
+# Makefile when running gnu make
+# If ESS EPICS ENVIRONMENT is set up, Makefile.EEE is used
+# Otherwise use Makefile
 
-TOP = .
-include $(TOP)/configure/CONFIG
-
-DIRS += configure axisApp
-axisApp_DEPEND_DIRS   = configure
-
-# To build axis examples;
-# 1st - uncomment lines below.
-# 2nd - uncomment required support module lines at the bottom of
-#       <axis>/configure/RELEASE.
-# 3rd - make clean uninstall
-# 4th - make
-
-#!DIRS += axisExApp iocBoot
-#!axisExApp_DEPEND_DIRS = axisApp
-#!iocBoot_DEPEND_DIRS    = axisExApp
-
-include $(TOP)/configure/RULES_TOP
+ifdef EPICS_ENV_PATH
+ifeq ($(EPICS_MODULES_PATH),/opt/epics/modules)
+ifeq ($(EPICS_BASES_PATH),/opt/epics/bases)
+include Makefile.EEE
+else
+include Makefile.epics
+endif
+else
+include Makefile.epics
+endif
+else
+include Makefile.epics
+endif
+ 

--- a/Makefile.EEE
+++ b/Makefile.EEE
@@ -1,0 +1,84 @@
+include ${EPICS_ENV_PATH}/module.Makefile
+USR_DEPENDENCIES = asyn,4.27.0
+
+TEMPLATES += axisApp/Db/asyn_auto_power.db
+TEMPLATES += axisApp/Db/asyn_axis.db
+TEMPLATES += axisApp/Db/basic_asyn_axis.db
+TEMPLATES += axisApp/Db/basic_axis.db
+TEMPLATES += axisApp/Db/coordTrans2D.db
+TEMPLATES += axisApp/Db/axis.db
+TEMPLATES += axisApp/Db/axisUtil.db
+TEMPLATES += axisApp/Db/pseudoAxis.db
+TEMPLATES += axisApp/Db/softAxisTest.db
+
+DBDS += ./axisApp/AxisSrc/axisSupport.dbd
+
+SUBSTITUTIONS=-none-
+
+OPIS=-none-
+
+SOURCES += axisApp/ACRSrc/ACRMotorDriver.cpp
+SOURCES += axisApp/AttocubeSrc/drvANC150Asyn.cc
+SOURCES += axisApp/AxisSrc/asynAxisAxis.cpp
+SOURCES += axisApp/AxisSrc/asynAxisController.cpp
+SOURCES += axisApp/AxisSrc/axisRecord.cc
+SOURCES += axisApp/AxisSrc/axisUtil.cc
+SOURCES += axisApp/AxisSrc/axisUtilAux.cc
+SOURCES += axisApp/AxisSrc/devAxisAsyn.c
+SOURCES += axisApp/AxisSrc/drvAxisAsyn.c
+SOURCES += axisApp/AxisSrc/paramLib.c
+SOURCES += axisApp/MicronixSrc/MMC200Driver.cpp
+SOURCES += axisApp/NPointSrc/C300MotorDriver.cpp
+ifdef AXIS_DEV
+ SOURCES += axisApp/NewportSrc/AG_CONEX.cpp
+ SOURCES += axisApp/NewportSrc/AG_UC.cpp
+ SOURCES += axisApp/NewportSrc/HXPDriver.cpp
+ SOURCES += axisApp/NewportSrc/NewportRegister.cc
+ SOURCES += axisApp/NewportSrc/SMC100Driver.cpp
+ SOURCES += axisApp/NewportSrc/SMC100Register.cc
+ SOURCES += axisApp/NewportSrc/Socket.cpp
+ SOURCES += axisApp/NewportSrc/XPSAsynInterpose.c
+ SOURCES += axisApp/NewportSrc/XPSAxis.cpp
+ SOURCES += axisApp/NewportSrc/XPSController.cpp
+ SOURCES += axisApp/NewportSrc/XPSGathering.c
+ SOURCES += axisApp/NewportSrc/XPSGathering2.c
+ SOURCES += axisApp/NewportSrc/XPSGatheringMain.c
+ SOURCES += axisApp/NewportSrc/XPSGatheringRegister.c
+ SOURCES += axisApp/NewportSrc/XPS_C8_drivers.cpp
+ SOURCES += axisApp/NewportSrc/asynOctetSocket.cpp
+ SOURCES += axisApp/NewportSrc/devESP300.cc
+ SOURCES += axisApp/NewportSrc/devMM3000.cc
+ SOURCES += axisApp/NewportSrc/devMM4000.cc
+ SOURCES += axisApp/NewportSrc/devPM500.cc
+ SOURCES += axisApp/NewportSrc/drvESP300.cc
+ SOURCES += axisApp/NewportSrc/drvMM3000.cc
+ SOURCES += axisApp/NewportSrc/drvMM4000.cc
+ SOURCES += axisApp/NewportSrc/drvMM4000Asyn.c
+ SOURCES += axisApp/NewportSrc/drvPM500.cc
+ SOURCES += axisApp/NewportSrc/drvXPSAsyn.c
+ SOURCES += axisApp/NewportSrc/drvXPSAsynAux.c
+ SOURCES += axisApp/NewportSrc/hxp_drivers.cpp
+ SOURCES += axisApp/NewportSrc/strtok_r.c
+ SOURCES += axisApp/NewportSrc/tclCall.cc
+ SOURCES += axisApp/NewportSrc/xps_ftp.c
+endif
+SOURCES += axisApp/OmsAsynSrc/omsBaseAxis.cpp
+SOURCES += axisApp/OmsAsynSrc/omsBaseController.cpp
+SOURCES += axisApp/OmsAsynSrc/omsMAXnet.cpp
+SOURCES += axisApp/OmsAsynSrc/omsMAXv.cpp
+SOURCES += axisApp/OmsAsynSrc/omsMAXvEncFunc.cpp
+SOURCES += axisApp/PIGCS2Src/PIC702Controller.cpp
+SOURCES += axisApp/PIGCS2Src/PIE517Controller.cpp
+SOURCES += axisApp/PIGCS2Src/PIE755Controller.cpp
+SOURCES += axisApp/PIGCS2Src/PIGCS2_HexapodController.cpp
+SOURCES += axisApp/PIGCS2Src/PIGCSController.cpp
+SOURCES += axisApp/PIGCS2Src/PIGCSMotorController.cpp
+SOURCES += axisApp/PIGCS2Src/PIGCSPiezoController.cpp
+SOURCES += axisApp/PIGCS2Src/PIHexapodController.cpp
+SOURCES += axisApp/PIGCS2Src/PIInterface.cpp
+SOURCES += axisApp/PIGCS2Src/PIasynAxis.cpp
+SOURCES += axisApp/PIGCS2Src/PIasynController.cpp
+SOURCES += axisApp/PIGCS2Src/translateerror.c
+SOURCES += axisApp/PhytronSrc/phytronAxisMotor.cpp
+SOURCES += axisApp/SmarActMCSSrc/smarActMCSMotorDriver.cpp
+SOURCES += axisExApp/WithAsyn/WithAsynMain.c

--- a/Makefile.epics
+++ b/Makefile.epics
@@ -1,0 +1,21 @@
+#Makefile at top of application tree
+# "#!" marks lines that can be uncommented.
+
+TOP = .
+include $(TOP)/configure/CONFIG
+
+DIRS += configure axisApp
+axisApp_DEPEND_DIRS   = configure
+
+# To build axis examples;
+# 1st - uncomment lines below.
+# 2nd - uncomment required support module lines at the bottom of
+#       <axis>/configure/RELEASE.
+# 3rd - make clean uninstall
+# 4th - make
+
+#!DIRS += axisExApp iocBoot
+#!axisExApp_DEPEND_DIRS = axisApp
+#!iocBoot_DEPEND_DIRS    = axisExApp
+
+include $(TOP)/configure/RULES_TOP


### PR DESCRIPTION
The EPICS version at ESS allows different versions of EPICS base,
modules (in our case asyn) to be compiled and installed side-by-side.

The make system is based on a version from PSI and has been presented here:
https://indico.esss.lu.se/event/507/session/2/contribution/54

In order to support the "classic" EPICS build systems and EEE, 2 different
Makefiles are used: Makefile.epics and Makefile.EEE.

The new Makefile is now a wrapper which decides on environment variables
EPICS_ENV_PATH, EPICS_MODULES_PATH and EPICS_BASES_PATH what to do.

This should work for all installations, if not, we will find a solution.
