### PR TITLE
Status of limit switches updated independent of movement direction. I…

### DIFF
--- a/axisApp/AxisSrc/axisRecord.cc
+++ b/axisApp/AxisSrc/axisRecord.cc
@@ -942,7 +942,12 @@ that it will happen when we return.
 ******************************************************************************/
 static void maybeRetry(axisRecord * pmr)
 {
-    if ((fabs(pmr->diff) >= pmr->rdbd) && !pmr->hls && !pmr->lls)
+    bool user_cdir;
+
+    /* Commanded direction in user coordinates. */
+    user_cdir = ((pmr->dir == motorDIR_Pos) == (pmr->mres >= 0)) ? pmr->cdir : !pmr->cdir;
+
+    if ((fabs(pmr->diff) >= pmr->rdbd) && !(pmr->hls && user_cdir) && !(pmr->lls && !user_cdir))
     {
         /* No, we're not close enough.  Try again. */
         Debug(1, "maybeRetry: not close enough; diff = %f\n", pmr->diff);
@@ -1251,7 +1256,7 @@ static long process(dbCommon *arg)
             }
 
             /* Do another update after LS error. */
-            if (pmr->mip != MIP_DONE && (pmr->rhls || pmr->rlls))
+            if (pmr->mip != MIP_DONE && ((pmr->rhls && pmr->cdir) || (pmr->rlls && !pmr->cdir)))
             {
                 /* Restore DMOV to false and UNMARK it so it is not posted. */
                 pmr->dmov = FALSE;
@@ -1280,7 +1285,8 @@ static long process(dbCommon *arg)
                     status = postProcess(pmr);
             }
 
-            if ((pmr->rhls || pmr->rlls) || (pmr->mip == MIP_LOAD_P)) /* Should we test for a retry? */
+            /* Should we test for a retry? Consider limit only if in direction of move.*/
+            if (((pmr->rhls && pmr->cdir) || (pmr->rlls && !pmr->cdir)) || (pmr->mip == MIP_LOAD_P))
             {
                 pmr->mip = MIP_DONE;
                 MARK(M_MIP);
@@ -3273,7 +3279,8 @@ static void alarm_sub(axisRecord * pmr)
         recGblSetSevr((dbCommon *) pmr, UDF_ALARM, INVALID_ALARM);
         return;
     }
-    /* limit-switch and soft-limit violations */
+    /* Limit-switch and soft-limit violations. Consider limit switches also if not in
+     * direction of move (limit hit by externally triggered move)*/
     if (pmr->hlsv && (pmr->hls || (pmr->dval > pmr->dhlm)))
     {
         recGblSetSevr((dbCommon *) pmr, HIGH_ALARM, pmr->hlsv);
@@ -3602,9 +3609,9 @@ static void process_motor_info(axisRecord * pmr, bool initcall)
     if (pmr->tdir != old_tdir)
         MARK(M_TDIR);
 
-    /* Get states of high, low limit switches. */
-    pmr->rhls = (msta.Bits.RA_PLUS_LS)  &&  pmr->cdir;
-    pmr->rlls = (msta.Bits.RA_MINUS_LS) && !pmr->cdir;
+    /* Get states of high, low limit switches. State is independent of direction. */
+    pmr->rhls = (msta.Bits.RA_PLUS_LS);
+    pmr->rlls = (msta.Bits.RA_MINUS_LS);
 
     if ((pmr->mip & MIP_HOMF) || (pmr->mip & MIP_HOMR))
     {
@@ -3612,7 +3619,10 @@ static void process_motor_info(axisRecord * pmr, bool initcall)
         msta.Bits.RA_PROBLEM = 0; /* Suppress problem while homing */
     }
     else
-        ls_active = (pmr->rhls || pmr->rlls) ? true : false;
+    {
+        /* Treat limit switch active only when it is pressed and in direction of movement. */
+        ls_active = ((pmr->rhls && pmr->cdir) || (pmr->rlls && !pmr->cdir)) ? true : false;
+    }
     
     pmr->hls = ((pmr->dir == motorDIR_Pos) == (pmr->mres >= 0)) ? pmr->rhls : pmr->rlls;
     pmr->lls = ((pmr->dir == motorDIR_Pos) == (pmr->mres >= 0)) ? pmr->rlls : pmr->rhls;


### PR DESCRIPTION
…ssue #35

The raw limit switches found in the MSTA field are converted into
LLS and HLS:
- When the DIR field is 1, they are swapped
- When the limit switch is not in the direction of the
  commanded direction, it is not shown.
  This is useful when a controller has only one bit which reports
  both limit switches.
  It had been useful when these controllers where more common.
  Today there are different reasons to remove this filtering
  from the record:
  - the motor can be moved outside the record into the other direction
  - The motor is slowly creeping towards the limit switch and hits it
  - The cable is broken or disconnected
  - The HOMF button is pressed and the motor starts his own homing sequence,
    which hits the low limit switch.

In any case, this kind of filtering can be done in the driver, if needed.
When hitting a limit switch while doing retries or backlash, the filter
is still used to stop (or not) the motor.
(I think that it would be safer to stop the motor whenever any limit switch
 is hit, but that is a seperate discussion, don't change this now)

Conflicts:
        axisApp/AxisSrc/axisRecord.cc